### PR TITLE
Root

### DIFF
--- a/src/emuapi.cpp
+++ b/src/emuapi.cpp
@@ -499,6 +499,12 @@ static bool setDirectory(const char* dir)
       }
     }
   }
+  else if (!dir[0])
+  {
+    // Root directory
+    dirPath[0] = 0;
+    retVal = true;
+  }
   return retVal;
 }
 

--- a/src/emuapi.cpp
+++ b/src/emuapi.cpp
@@ -475,35 +475,41 @@ static bool setDirectory(const char* dir)
 {
   bool retVal = false;
 
-  if (dir!=NULL && dir[0])
+  if (dir!=NULL)
   {
-    if (dir[strlen(dir) - 1] != '/')
+    if (dir[0])
     {
-      if (strncasecmp(dirPath, dir, strlen(dir) - 1) ||
-          (strlen(dir) != (strlen(dirPath) - 1)))
+      if (dir[strlen(dir) - 1] != '/')
       {
-        strncpy(dirPath, dir, MAX_DIRECTORY_LEN-2);
-        dirPath[MAX_DIRECTORY_LEN-2] = 0;
-        strcat(dirPath, "/");
-        retVal = true;
+        if (strncasecmp(dirPath, dir, strlen(dir) - 1) ||
+            (strlen(dir) != (strlen(dirPath) - 1)))
+        {
+          strncpy(dirPath, dir, MAX_DIRECTORY_LEN-2);
+          dirPath[MAX_DIRECTORY_LEN-2] = 0;
+          strcat(dirPath, "/");
+          retVal = true;
+        }
+      }
+      else
+      {
+        if (strncasecmp(dirPath, dir, strlen(dir)) ||
+            (strlen(dir) != strlen(dirPath)))
+        {
+          strncpy(dirPath, dir, MAX_DIRECTORY_LEN-1);
+          dirPath[MAX_DIRECTORY_LEN-1] = 0;
+          retVal = true;
+        }
       }
     }
     else
     {
-      if (strncasecmp(dirPath, dir, strlen(dir)) ||
-          (strlen(dir) != strlen(dirPath)))
+      if (dirPath[0])
       {
-        strncpy(dirPath, dir, MAX_DIRECTORY_LEN-1);
-        dirPath[MAX_DIRECTORY_LEN-1] = 0;
+        // Moving to root directory
+        dirPath[0] = 0;
         retVal = true;
       }
     }
-  }
-  else if (!dir[0])
-  {
-    // Root directory
-    dirPath[0] = 0;
-    retVal = true;
   }
   return retVal;
 }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -550,7 +550,14 @@ bool statusMenu(void)
     }
 
     writeString("Directory:", lhs, ++lcount);
-    writeString(emu_GetDirectory(), rhs, lcount++);
+    if (!emu_GetDirectory()[0])
+    {
+        writeString("<ROOT>", rhs, lcount++);
+    }
+    else
+    {
+        writeString(emu_GetDirectory(), rhs, lcount++);
+    }
 
 #ifdef NINEPIN_JOYSTICK
     writeString("Nine Pin JS:", lhs, lcount);


### PR DESCRIPTION
Fix bug when F2 moves to root directory
Explicitly display the root directory (rather than empty string) in the F3 menu