### PR TITLE
SDK 2.2.0

### DIFF
--- a/boards/mcu.h
+++ b/boards/mcu.h
@@ -1,6 +1,8 @@
 #ifndef _MCU_H_
 #define _MCU_H_
 
+#include <pico.h>   // Needed for CMake macro definitions
+
 #ifdef PICO_2350
 #include <boards/pico2.h>
 #else


### PR DESCRIPTION
Include `pico.h` from `mcu.h`, to prevent build failures with SDK 2.2.0